### PR TITLE
Compatibility with IDEA 11

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -3,6 +3,10 @@
     <description>This plugin integrates the Leiningen build system into IntelliJ IDEA.</description>
     <change-notes>
         <![CDATA[
+        <p>Version 0.2.1</p>
+        <ul>
+            <li>Made plugin compatible with IntelliJ IDEA 11</li>
+        </ul>
         <p>Version 0.2</p>
         <ul>
             <li>Fixed project.clj file parsing</li>
@@ -44,7 +48,7 @@
     </change-notes>
     <version>0.2</version>
     <vendor email="janthomae@janthomae.de" url="http://github.com/derkork/intellij-leiningen-plugin">Jan Thomä</vendor>
-    <idea-version since-build="107.000" until-build="107.9999"/>
+    <idea-version since-build="107.000" until-build="111.9999"/>
 
     <application-components>
     </application-components>

--- a/leiningen-plugin.ipr
+++ b/leiningen-plugin.ipr
@@ -308,6 +308,27 @@
       </item>
     </group>
   </component>
+  <component name="ProjectCodeStyleSettingsManager">
+    <option name="PER_PROJECT_SETTINGS">
+      <value>
+        <XML>
+          <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+        </XML>
+        <ADDITIONAL_INDENT_OPTIONS fileType="groovy">
+          <option name="INDENT_SIZE" value="2" />
+        </ADDITIONAL_INDENT_OPTIONS>
+        <ADDITIONAL_INDENT_OPTIONS fileType="yml">
+          <option name="INDENT_SIZE" value="2" />
+        </ADDITIONAL_INDENT_OPTIONS>
+        <codeStyleSettings language="JavaScript">
+          <indentOptions>
+            <option name="CONTINUATION_INDENT_SIZE" value="8" />
+          </indentOptions>
+        </codeStyleSettings>
+      </value>
+    </option>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </component>
   <component name="ProjectKey">
     <option name="state" value="project://default" />
   </component>


### PR DESCRIPTION
Hello,

I made plugin compatible with IDEA 11. It required only small tweak of plugin.xml though :) But it is important to put it into plugin repository ASAP because current version will not work with IDEA 11, and plugin manager will install only some ancient version of it.

Regards,
Vladimir.
