### PR TITLE
Leiningen Plugins

### DIFF
--- a/leiningen-plugin.iml
+++ b/leiningen-plugin.iml
@@ -22,7 +22,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/clojure-1.1.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/lib/clojure-1.2.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject de.janthomae/leiningenplugin "1.1.0-SNAPSHOT"
   :description "IntelliJ plugin for controlling Leiningen"
-  :dependencies [[org.clojure/clojure "1.1.0"]]
+  :dependencies [[org.clojure/clojure "1.2.1"]]
   :dev-dependencies [[junit/junit "4.8.2"]]
   :source-path "src"
   :resources-path "lein-resources"

--- a/src/de/janthomae/leiningenplugin/run/LeiningenRunnerSettings.java
+++ b/src/de/janthomae/leiningenplugin/run/LeiningenRunnerSettings.java
@@ -24,9 +24,12 @@ public class LeiningenRunnerSettings implements PersistentStateComponent<Leining
     @NotNull
     String leiningenPath = "/please/set/me/up/in/settings/leiningen";
 
+    public
+    @NotNull
+    String leiningenHome = System.getProperty("user.home") + "/.lein";
+
     public static LeiningenRunnerSettings getInstance() {
         return ServiceManager.getService(LeiningenRunnerSettings.class);
-
     }
 
     public LeiningenRunnerSettings getState() {
@@ -35,6 +38,5 @@ public class LeiningenRunnerSettings implements PersistentStateComponent<Leining
 
     public void loadState(LeiningenRunnerSettings leiningenRunnerSettings) {
         XmlSerializerUtil.copyBean(leiningenRunnerSettings, this);
-
     }
 }

--- a/src/de/janthomae/leiningenplugin/settings/LeiningenSettings.java
+++ b/src/de/janthomae/leiningenplugin/settings/LeiningenSettings.java
@@ -19,7 +19,8 @@ import java.awt.*;
  * @version $Id:$
  */
 public class LeiningenSettings implements Configurable {
-    private TextFieldWithBrowseButton selectorField;
+    private TextFieldWithBrowseButton leinBinSelectorField;
+    private TextFieldWithBrowseButton leinHomeSelectorField;
     private UserActivityWatcher myWatcher;
     private boolean changed = false;
 
@@ -38,14 +39,29 @@ public class LeiningenSettings implements Configurable {
 
     public JComponent createComponent() {
         JPanel outerPanel = new JPanel(new BorderLayout());
-        JPanel panel = new JPanel(new BorderLayout());
-        panel.add(new JLabel("Path to Leiningen executable:"), BorderLayout.WEST);
-        this.selectorField = new TextFieldWithBrowseButton();
-        selectorField
+        
+        JPanel leinPanel = new JPanel(new GridLayout(0,1));
+
+        JPanel leinHomePanel = new JPanel(new BorderLayout());
+        leinHomePanel.add(new JLabel("Path to Leiningen home directory:"), BorderLayout.WEST);
+        this.leinHomeSelectorField = new TextFieldWithBrowseButton();
+        leinHomeSelectorField
+                .addBrowseFolderListener("Select the Leiningen home directory", "~/.lein on Linux/MacOS.", null,
+                        new FileChooserDescriptor(false, true, false, false, false, false));
+        leinHomePanel.add(this.leinHomeSelectorField, BorderLayout.CENTER);
+        leinPanel.add(leinHomePanel);
+
+        JPanel leinBinPanel = new JPanel(new BorderLayout());
+        leinBinPanel.add(new JLabel("Path to Leiningen executable:"), BorderLayout.WEST);
+        this.leinBinSelectorField = new TextFieldWithBrowseButton();
+        leinBinSelectorField
                 .addBrowseFolderListener("Select the Leiningen executable", "'lein' on Linux/MacOS, 'lein.bat' on Windows. ", null,
                         new FileChooserDescriptor(true, false, false, false, false, false));
-        panel.add(this.selectorField, BorderLayout.CENTER);
-        outerPanel.add(panel, BorderLayout.NORTH);
+        leinBinPanel.add(this.leinBinSelectorField, BorderLayout.CENTER);
+        leinPanel.add(leinBinPanel);
+
+        outerPanel.add(leinPanel, BorderLayout.NORTH);
+
         myWatcher = new UserActivityWatcher();
         myWatcher.register(outerPanel);
         myWatcher.addUserActivityListener(new UserActivityListener() {
@@ -62,14 +78,16 @@ public class LeiningenSettings implements Configurable {
 
     public void apply() throws ConfigurationException {
         LeiningenRunnerSettings settings = LeiningenRunnerSettings.getInstance();
-        settings.leiningenPath = selectorField.getText();
+        settings.leiningenPath = leinBinSelectorField.getText();
+        settings.leiningenHome = leinHomeSelectorField.getText();
         changed = false;
     }
 
     public void reset() {
         changed = false;
         LeiningenRunnerSettings settings = LeiningenRunnerSettings.getInstance();
-        selectorField.setText(settings.leiningenPath);
+        leinBinSelectorField.setText(settings.leiningenPath);
+        leinHomeSelectorField.setText(settings.leiningenHome);
     }
 
     public void disposeUIResources() {


### PR DESCRIPTION
I made a few changes to make sure that leiningen plugins ("~/.lein/plugins/_.jar") and the leiningen standalone jar ("~/.lein/self-installs/_.jar") get added to the same classpath as the clojure library. I did this in order to successfully load some project.clj files that include require statements before 'defproject', to use certain plugins in the project.clj itself.

I also bumped the clojure dependency to 1.2.1, to squash some java.lang.VerifyErrors when using plugin against projects with 1.2.1 and 1.3.0 clojure dependencies. I'm not sure why this was necessary, and am open to reverting the change if there is another workaround.

Regards,
-John Chapin
